### PR TITLE
styling for org/user/event edit pages

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -20,7 +20,7 @@
 
   <div class="field">
     <%= f.label :description %><br />
-    <%= f.text_area :description, rows:4, cols:55, class: "width-med" %>
+    <%= f.text_area :description, rows: 4, cols: 55, class: "width-med" %>
   </div>
   
   <br />

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,6 +1,8 @@
+<div class="center-form width-med">
 <h1>Editing Event</h1>
 
 <%= render 'form', event: @event %>
 
 <%= link_to 'Show', @event %> |
 <%= link_to 'Back', events_path %>
+</div>

--- a/app/views/organizations/registrations/edit.html.erb
+++ b/app/views/organizations/registrations/edit.html.erb
@@ -1,9 +1,14 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="center-form">
+  <h2>Edit <%= resource_name.to_s.humanize %></h2>
+</div>
+
+</br>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
-  
-    <div class="field">
+ 
+  <div class="center-form width-med">
+  <div class="field">
     <%= f.label :name %><br />
     <%= f.text_field :name %>
   </div>
@@ -35,14 +40,17 @@
 
   <div class="field">
     <%= f.label :mission %><br />
-    <%= f.text_field :mission %>
+    <%= f.text_area :mission, rows: 4, cols: 55, class: "width-med" %>
   </div>
 
   <div class="field">
     <%= f.label :website %><br />
     <%= f.text_field :website %>
   </div>
-
+  
+  </div>
+  
+  <div class="center-form width-lg">
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true %>
@@ -51,6 +59,8 @@
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
+  
+  </br>
 
   <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
@@ -60,7 +70,7 @@
       <em><%= @minimum_password_length %> characters minimum</em>
     <% end %>
   </div>
-
+  
   <div class="field">
     <%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
@@ -70,7 +80,9 @@
     <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
     <%= f.password_field :current_password, autocomplete: "off" %>
   </div>
-
+  
+  </br>
+  
   <div class="actions">
     <%= f.submit "Update" %>
   </div>
@@ -81,3 +93,4 @@
 <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>
+</div>

--- a/app/views/organizations/registrations/new.html.erb
+++ b/app/views/organizations/registrations/new.html.erb
@@ -92,7 +92,7 @@
  
   <div class="field">
     <%= f.label :mission %><br />
-    <%= f.text_area :mission, rows: "4", cols: "55", class: "width-med"%> 
+    <%= f.text_area :mission, rows: 4, cols: 55, class: "width-med"%> 
   </div>
 
   <div class="field">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,9 +1,12 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="center-form">
+  <h2>Edit <%= resource_name.to_s.humanize %></h2>
+</div>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
   
-    <div class="field">
+  <div class="center-form width-sm">
+  <div class="field">
     <%= f.label :first_name %><br />
     <%= f.text_field :first_name %>
   </div>
@@ -37,7 +40,10 @@
     <%= f.label :phone_number %><br />
     <%= f.text_field :phone_number %>
   </div>
-
+  
+  </div>
+  
+  <div class="center-form width-lg">
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true %>
@@ -71,6 +77,8 @@
     <%= f.password_field :current_password, autocomplete: "off" %>
   </div>
 
+  </br>
+
   <div class="actions">
     <%= f.submit "Update" %>
   </div>
@@ -81,3 +89,4 @@
 <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>
+</div>


### PR DESCRIPTION
Better styling for the pages that edit an organization, user and event. Matches the styling on the sign-up and new pages.