### PR TITLE
events: Keep track of week/month view in the GET params.

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,7 +17,7 @@
     display: none
   }
   </style>
-  <input id="toggle-event" type="checkbox">
+  <input id="toggle-event" type="checkbox" <%= params['view'] == 'week' ? 'checked' : '' %>>
   <div id="console-event"></div>
   <script>
     $(function() {
@@ -37,7 +37,7 @@
     })
   </script>
   
-  <div class="js-weekly-calendar hidden">
+  <div class="js-weekly-calendar <%= params['view'] == 'week' ? '' : 'hidden' %>">
     <%= week_calendar events: @events do |date, events| %>
       <%= date.strftime("%e") %>
       <% events.each do |event| %>
@@ -49,7 +49,7 @@
     <% end %>
   </div>
 
-  <div class="js-monthly-calendar">
+  <div class="js-monthly-calendar <%= params['view'] == 'week' ? 'hidden' : '' %>">
     <%= month_calendar events: @events do |date, events| %>
       <%= date.strftime("%e") %>
       <% events.each do |event| %>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -4,14 +4,27 @@
   }
 </style>
 
+<%
+
+require 'uri'
+
+def set_get_param(uristr, param, value)
+  uri = URI.parse(uristr)
+  query = Hash[URI.decode_www_form(String(uri.query))]
+  query[param] = value;
+  uri.query = URI.encode_www_form(query)
+  return uri.to_s
+end
+
+%>
 
 <div class="simple-calendar">
   <div class="calendar-heading" style="font-size: 175%;">
-    <%= link_to t('simple_calendar.previous', default: '&#x21E6;'.html_safe), calendar.url_for_previous_view, class: "active_arrows" %>
+    <%= link_to(t('simple_calendar.previous', default: '&#x21E6;'.html_safe), set_get_param(calendar.url_for_previous_view,'view','month'), class: "active_arrows") %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-      <%= link_to t('simple_calendar.next', default: '&#x21E8;'.html_safe), calendar.url_for_next_view, class: "active_arrows" %>
+    <%= link_to(t('simple_calendar.next', default: '&#x21E8;'.html_safe), set_get_param(calendar.url_for_next_view,'view','month'), class: "active_arrows") %>
   </div>
-  
+
   <table class="table table-striped">
     <thead>
       <tr>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -4,15 +4,29 @@
   }
 </style>
 
+<%
+
+require 'uri'
+
+def set_get_param(uristr, param, value)
+  uri = URI.parse(uristr)
+  query = Hash[URI.decode_www_form(String(uri.query))]
+  query[param] = value;
+  uri.query = URI.encode_www_form(query)
+  return uri.to_s
+end
+
+%>
+
 <div class="simple-calendar">
   <div class="calendar-heading" style="font-size: 150%;">
-    <%= link_to t('simple_calendar.previous', default: '&#x21E6;'.html_safe), calendar.url_for_previous_view, class: "active_arrows"  %>
+    <%= link_to(t('simple_calendar.previous', default: '&#x21E6;'.html_safe), set_get_param(calendar.url_for_previous_view,'view','week'), class: "active_arrows") %>
     <% if calendar.number_of_weeks == 1 %>
       <span class="calendar-title">Week <%= calendar.week_number %></span>
     <%else%>
         <span class="calendar-title">Week <%= calendar.week_number %> - <%= calendar.end_week %></span>
     <%end%>
-        <%= link_to t('simple_calendar.next', default: '&#x21E8;'.html_safe), calendar.url_for_next_view, class: "active_arrows" %>
+    <%= link_to(t('simple_calendar.next', default: '&#x21E8;'.html_safe), set_get_param(calendar.url_for_next_view,'view','week'), class: "active_arrows") %>
   </div>
 
   <table class="table table-striped">


### PR DESCRIPTION
Fixes <https://trello.com/c/b1qRuW8S/105-calendar-week-month-switch-issue>.

Please review.