### PR TITLE
(Accessibility) changed Sign in to Login

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -31,7 +31,7 @@
           </li>
           <% else %>
           <li style="float:right">
-           <a  href="/static_pages/signin_options">Sign In</a>
+           <a  href="/static_pages/signin_options">Log In</a>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Quick fix: According to [accessibility recommendations](https://docs.google.com/document/d/1c4hEJ4erWg6n_InXnBwphLrFTvFFSjfLfq5ksXgYVHA/edit#) by Vannessa we need to change "Sign in" to "Log in" so that its distinguishable from "Sign Up"