### PR TITLE
Event controller branch

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -52,8 +52,8 @@ class EventsController < InheritedResources::Base
     else
       # Changing "Num vols" to "Number of Volunteers" is a bit of a hack,
       #   but I couldn't find a better solution yet
-      flash[:error] ||= @event.errors.full_messages.join("<br/>")
-          .gsub("Num vols", "Number of Volunteers")
+      # flash[:error] ||= @event.errors.full_messages.join("<br/>")
+      #     .gsub("Num vols", "Number of Volunteers")
       # redirect_back(fallback_location: root_path)
       # rerender the page with all entered fields saved.
       render "events/new"
@@ -77,13 +77,10 @@ class EventsController < InheritedResources::Base
     @event = Event.find(params[:id])
     
     if (@event.update(event_info))
+      flash[:notice] = "You successfully updated your event!"
       redirect_to @event
     else
-      # Changing "Num vols" to "Number of Volunteers" is a bit of a hack,
-      #   but I couldn't find a better solution yet
-      flash[:error] ||= @event.errors.full_messages.join("<br/>")
-          .gsub("Num vols", "Number of Volunteers")
-      redirect_back(fallback_location: root_path)
+      render "events/new"
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -53,7 +53,9 @@ class EventsController < InheritedResources::Base
       #   but I couldn't find a better solution yet
       flash[:error] ||= @event.errors.full_messages.join("<br/>")
           .gsub("Num vols", "Number of Volunteers")
-      redirect_back(fallback_location: root_path)
+      # redirect_back(fallback_location: root_path)
+      # rerender the page with all entered fields saved.
+      render "events/new"
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -47,6 +47,7 @@ class EventsController < InheritedResources::Base
     @event = current_organization.events.new(event_info)  
 
     if @event.save
+      flash[:notice] = "You successfully created an event!"
       redirect_to events_path
     else
       # Changing "Num vols" to "Number of Volunteers" is a bit of a hack,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -4,6 +4,7 @@
   <% if event.errors.any? %>
     <div id="error_explanation">
       <p style="text-align:center; color:red; font-weight:bold"><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</p>
+      <%= devise_error_messages! %>
     </div>
   <% end %>
   

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -3,13 +3,7 @@
 <%= form_for(event) do |f| %>
   <% if event.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</h2>
-
-      <ul>
-      <% event.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
+      <p style="text-align:center; color:red; font-weight:bold"><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</p>
     </div>
   <% end %>
   


### PR DESCRIPTION
This branch simply fixes the issue where registration errors refreshes the pages and does not retain user inputs. Issue on Trello mentioned [here](https://trello.com/c/v7rPCLI2/23-3-forms-should-retain-their-information-if-the-user-makes-a-mistake). Please test and review.